### PR TITLE
Save invoice & response xml to specified folder

### DIFF
--- a/AmiKo Desitin.entitlements
+++ b/AmiKo Desitin.entitlements
@@ -25,6 +25,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 	<key>com.apple.security.personal-information.addressbook</key>
 	<true/>
 	<key>com.apple.security.print</key>

--- a/AmiKoOSX/Medidata/MLMedidataResponsesWindowController.m
+++ b/AmiKoOSX/Medidata/MLMedidataResponsesWindowController.m
@@ -199,7 +199,7 @@
         NSURL *folderURL = [[MLPersistenceManager shared] medidataInvoiceResponseXMLDirectory];
         if ([folderURL startAccessingSecurityScopedResource]) {
             NSString *filename = response.amkFilePath.lastPathComponent ?: response.document.transmissionReference;
-            NSURL *fileURL = [folderURL URLByAppendingPathComponent:[filename stringByAppendingString:@".xml"]];
+            NSURL *fileURL = [folderURL URLByAppendingPathComponent:[filename stringByAppendingString:@"-response.xml"]];
             [[[MedidataClient alloc] init]
              downloadInvoiceResponseWithTransmissionReference:response.document.transmissionReference
              toFile:fileURL

--- a/AmiKoOSX/Medidata/MLMedidataResponsesWindowController.m
+++ b/AmiKoOSX/Medidata/MLMedidataResponsesWindowController.m
@@ -182,20 +182,43 @@
     if (!response.canConfirm) {
         return;
     }
-    NSSavePanel *savePanel = [NSSavePanel savePanel];
-    [savePanel setNameFieldStringValue:[NSString stringWithFormat:@"%@.txt", response.amkFilePath.lastPathComponent.stringByDeletingPathExtension]];
-    NSModalResponse returnCode = [savePanel runModal];
-    if (returnCode == NSFileHandlingPanelOKButton) {
-        [[[MedidataClient alloc] init]
-         downloadInvoiceResponseWithTransmissionReference:response.document.transmissionReference
-         toFile:savePanel.URL
-         completion:^(NSError * _Nonnull error) {
-            if (error) {
+    if (![[MLPersistenceManager shared] hadSetupMedidataInvoiceResponseXMLDirectory]) {
+        NSOpenPanel *openPanel = [NSOpenPanel openPanel];
+        [openPanel setCanChooseFiles:NO];
+        [openPanel setCanChooseDirectories:YES];
+        [openPanel setCanCreateDirectories:YES];
+        [openPanel setAllowsMultipleSelection:NO];
+
+        NSModalResponse returnCode = [openPanel runModal];
+        if (returnCode == NSFileHandlingPanelOKButton) {
+            [[MLPersistenceManager shared] setMedidataInvoiceResponseXMLDirectory:openPanel.URL];
+        }
+    }
+    
+    if ([[MLPersistenceManager shared] hadSetupMedidataInvoiceResponseXMLDirectory]) {
+        NSURL *folderURL = [[MLPersistenceManager shared] medidataInvoiceResponseXMLDirectory];
+        if ([folderURL startAccessingSecurityScopedResource]) {
+            NSString *filename = response.amkFilePath.lastPathComponent ?: response.document.transmissionReference;
+            NSURL *fileURL = [folderURL URLByAppendingPathComponent:[filename stringByAppendingString:@".xml"]];
+            [[[MedidataClient alloc] init]
+             downloadInvoiceResponseWithTransmissionReference:response.document.transmissionReference
+             toFile:fileURL
+             completion:^(NSError * _Nonnull error) {
+                [folderURL stopAccessingSecurityScopedResource];
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [[NSAlert alertWithError:error] runModal];
+                    if (error) {
+                        [[NSAlert alertWithError:error] runModal];
+                    } else {
+                        NSAlert *alert = [[NSAlert alloc] init];
+                        [alert setMessageText:NSLocalizedString(@"Downloaded", @"")];
+                        [alert setInformativeText:[NSString stringWithFormat:NSLocalizedString(@"Downloaded to %@", @""), fileURL.path]];
+                        [alert runModal];
+                    }
                 });
-            }
-        }];
+            }];
+        } else {
+            NSLog(@"Cannot access invoice response's secure URL");
+        }
     }
 }
 

--- a/CoMed Desitin.entitlements
+++ b/CoMed Desitin.entitlements
@@ -31,5 +31,7 @@
 	<true/>
 	<key>com.apple.security.smartcard</key>
 	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 </dict>
 </plist>

--- a/Persistence/MLPersistenceManager.h
+++ b/Persistence/MLPersistenceManager.h
@@ -29,6 +29,13 @@ typedef NS_ENUM(NSInteger, MLPersistenceSource) {
 - (void)setCurrentSourceToICloud;
 - (void)setCurrentSourceToLocalWithDeleteICloud:(BOOL)deleteFilesOnICloud;
 
+- (BOOL)hadSetupMedidataInvoiceXMLDirectory;
+- (NSURL *)medidataInvoiceXMLDirectory;
+- (void)setMedidataInvoiceXMLDirectory:(NSURL *)url;
+- (BOOL)hadSetupMedidataInvoiceResponseXMLDirectory;
+- (NSURL *)medidataInvoiceResponseXMLDirectory;
+- (void)setMedidataInvoiceResponseXMLDirectory:(NSURL *)url;
+
 # pragma mark - Doctor
 
 - (NSURL *)doctorDictionaryURL;

--- a/Persistence/MLPersistenceManager.m
+++ b/Persistence/MLPersistenceManager.m
@@ -14,6 +14,8 @@
 #import "MLPatientSync.h"
 
 #define KEY_PERSISTENCE_SOURCE @"KEY_PERSISTENCE_SOURCE"
+#define KEY_MEDIDATA_INVOICE_XML_DIRECTORY @"KEY_MEDIDATA_INVOICE_XML_DIRECTORY"
+#define KEY_MEDIDATA_INVOICE_RESPONSE_XML_DIRECTORY @"KEY_MEDIDATA_INVOICE_RESPONSE_XML_DIRECTORY"
 
 @interface MLPersistenceManager () <MLiCloudToLocalMigrationDelegate>
 
@@ -147,6 +149,84 @@
     if (error != nil) {
         NSLog(@"Cannot start downloading favourite %@", error);
     }
+}
+
+- (BOOL)hadSetupMedidataInvoiceXMLDirectory {
+    NSData *bookmark = [[NSUserDefaults standardUserDefaults] objectForKey:KEY_MEDIDATA_INVOICE_XML_DIRECTORY];
+    return bookmark != nil;
+}
+
+- (NSURL *)medidataInvoiceXMLDirectory {
+    NSData *bookmark = [[NSUserDefaults standardUserDefaults] objectForKey:KEY_MEDIDATA_INVOICE_XML_DIRECTORY];
+    if (!bookmark) {
+        return nil;
+    }
+    NSError *error = nil;
+    BOOL isStale = NO;
+    NSURL *url = [NSURL URLByResolvingBookmarkData:bookmark
+                                           options:NSURLBookmarkResolutionWithSecurityScope
+                                     relativeToURL:nil
+                               bookmarkDataIsStale:&isStale
+                                             error:&error];
+    if (error) {
+        NSLog(@"%@", [error description]);
+        return nil;
+    }
+    if (isStale) {
+        [self setMedidataInvoiceXMLDirectory:url];
+    }
+    return url;
+}
+
+- (void)setMedidataInvoiceXMLDirectory:(NSURL *)url {
+    NSError *error = nil;
+    NSData *data = [url bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
+                 includingResourceValuesForKeys:nil
+                                  relativeToURL:nil error:&error];
+    if (error) {
+        NSLog(@"%@", [error description]);
+    } else {
+        [[NSUserDefaults standardUserDefaults] setObject:data forKey:KEY_MEDIDATA_INVOICE_XML_DIRECTORY];
+    }
+}
+
+- (BOOL)hadSetupMedidataInvoiceResponseXMLDirectory {
+    return [[NSUserDefaults standardUserDefaults] objectForKey:KEY_MEDIDATA_INVOICE_RESPONSE_XML_DIRECTORY] != nil;
+}
+
+- (NSURL *)medidataInvoiceResponseXMLDirectory {
+    NSData *bookmark = [[NSUserDefaults standardUserDefaults] objectForKey:KEY_MEDIDATA_INVOICE_RESPONSE_XML_DIRECTORY];
+    if (!bookmark) {
+        return nil;
+    }
+    NSError *error = nil;
+    BOOL isStale = NO;
+    NSURL *url = [NSURL URLByResolvingBookmarkData:bookmark
+                                           options:NSURLBookmarkResolutionWithSecurityScope
+                                     relativeToURL:nil
+                               bookmarkDataIsStale:&isStale
+                                             error:&error];
+    if (error) {
+        NSLog(@"%@", [error description]);
+        return nil;
+    }
+    if (isStale) {
+        [self setMedidataInvoiceResponseXMLDirectory:url];
+    }
+    return url;
+}
+
+- (void)setMedidataInvoiceResponseXMLDirectory:(NSURL *)url {
+    NSError *error = nil;
+    NSData *bookmark = [url bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
+                     includingResourceValuesForKeys:nil
+                                      relativeToURL:nil
+                                              error:&error];
+    if (error) {
+        NSLog(@"%@", [error description]);
+        return;
+    }
+    [[NSUserDefaults standardUserDefaults] setObject:bookmark forKey:KEY_MEDIDATA_INVOICE_RESPONSE_XML_DIRECTORY];
 }
 
 # pragma mark - Migration Local -> iCloud


### PR DESCRIPTION
#231 

> The suggested Dir should be `~/medidata_invoice_xml`
> The suggested Dir should be `~/medidata_invoice_response_xml`

We cannot set a default directory, due to the design of [App Sandbox](https://developer.apple.com/library/archive/documentation/Security/Conceptual/AppSandboxDesignGuide/AppSandboxInDepth/AppSandboxInDepth.html). Anyway the user can select a folder to save the files. If the user does not choose any folder, nothing will be saved.

> The filenames of the invoice and invoice response xml should be the same like the amk file.

The AMK filename will be used, but if it's not found (e.g. the user deleted the AMK after uploading to Medidata, or another user of the same GLN has uploaded the AMK file to Medidata), the transmission reference will be used.

